### PR TITLE
 fix a warning in PHP 8.0

### DIFF
--- a/src/string.php
+++ b/src/string.php
@@ -447,7 +447,7 @@ function format_size($size, $dot = 2){
  * @return int
  */
 function resolve_size($val){
-	$last = strtolower($val{strlen($val) - 1});
+	$last = strtolower($val[strlen($val) - 1]);
 	switch($last){
 		case 'g':
 			$val *= 1024;


### PR DESCRIPTION
Array and string offset access syntax with curly braces is no longer supported in PHP8.0